### PR TITLE
use null object pattern to avoid type error

### DIFF
--- a/lib/polylines/decoder.rb
+++ b/lib/polylines/decoder.rb
@@ -9,8 +9,8 @@ module Polylines
 
         while points_with_deltas.any?
           points << [
-            points.last[0] + points_with_deltas.shift,
-            points.last[1] + points_with_deltas.shift
+            points.last[0] + (points_with_deltas.shift || 0.0),
+            points.last[1] + (points_with_deltas.shift || 0.0)
           ]
         end
       end


### PR DESCRIPTION
As mentioned in the issues there are a few polylines that, for whatever reason, create a `points_with_deltas` that have final coordinates missing a final latitude? Not sure if this is totally true as I didn't investigate thoroughly, but to avoid type error when adding a number to `[].shift` we can default to zero.